### PR TITLE
feat: migrate eval system to DeepEval framework

### DIFF
--- a/evals/.gitignore
+++ b/evals/.gitignore
@@ -1,0 +1,1 @@
+.deepeval/

--- a/evals/MIGRATION.md
+++ b/evals/MIGRATION.md
@@ -1,0 +1,147 @@
+# Migration Guide: Custom Eval System to DeepEval
+
+This guide explains the migration from the custom evaluation system to DeepEval.
+
+## What Changed
+
+### Before (Custom System)
+- Custom `run_eval.py` scripts for each tool
+- Manual LLM judge implementation with custom prompts
+- Custom SQLite storage layer
+- Results stored in database with comparison tools
+- Run via: `uv run evals/commit_changes/run_eval.py`
+
+### After (DeepEval)
+- Pytest-based test suite with `test_*.py` files
+- DeepEval's GEval metric for standardized evaluation
+- Built-in pytest reporting and storage
+- Standard test framework with pass/fail assertions
+- Run via: `pytest commit_changes/`
+
+## Key Benefits
+
+1. **Standardization**: Uses industry-standard testing framework (pytest)
+2. **Better Tooling**: Leverage pytest plugins for reporting, coverage, etc.
+3. **Clearer Results**: Pass/fail based on thresholds instead of just scores
+4. **Easier Extension**: Simple to add new metrics and test cases
+5. **CI/CD Integration**: Native pytest support in most CI/CD platforms
+
+## Migration Steps
+
+### For Users
+
+1. **Install new dependencies**:
+   ```bash
+   cd evals
+   uv pip install -e .
+   ```
+
+2. **Run tests instead of scripts**:
+   ```bash
+   # Old way
+   uv run evals/commit_changes/run_eval.py --case basic_feature
+
+   # New way
+   pytest commit_changes/test_commit_eval.py::test_commit_message_generation[basic_feature] -v
+   ```
+
+3. **View results**:
+   ```bash
+   # Old way
+   uv run evals/commit_changes/run_eval.py --summary
+
+   # New way
+   pytest commit_changes/ -v  # Shows pass/fail
+   pytest --html=report.html --self-contained-html  # Generate HTML report
+   ```
+
+### For Developers
+
+1. **Test case structure remains the same**:
+   - Still use `diff.txt` and `expected_elements.json`
+   - Test cases are automatically discovered
+   - No changes needed to existing test case directories
+
+2. **Adding new test cases**:
+   ```bash
+   # Old way: Create files, then run script
+   mkdir evals/commit_changes/new_case
+   # Add files...
+   uv run evals/commit_changes/run_eval.py --case new_case
+
+   # New way: Create files, pytest auto-discovers
+   mkdir evals/commit_changes/new_case
+   # Add files...
+   pytest commit_changes/ -v  # Automatically finds and runs new case
+   ```
+
+3. **Customizing evaluation**:
+   ```python
+   # Old way: Modify JUDGE_PROMPT in run_eval.py
+   JUDGE_PROMPT = """Your custom prompt..."""
+
+   # New way: Modify GEval metric in test file
+   commit_message_metric = GEval(
+       name="commit_message_quality",
+       criteria="Your custom criteria...",
+       threshold=0.7,
+   )
+   ```
+
+## Backwards Compatibility
+
+The old `run_eval.py` scripts are **deprecated but still functional**. They are kept for backwards compatibility and will be removed in a future version.
+
+If you need the old behavior:
+```bash
+uv run evals/commit_changes/run_eval.py  # Still works
+```
+
+However, we recommend migrating to the new pytest-based system.
+
+## Database Storage
+
+The old SQLite storage system (`evals/storage/`) is deprecated. DeepEval and pytest provide their own result storage and reporting mechanisms:
+
+- **Test results**: Use `pytest --json-report` or `pytest --html`
+- **Historical tracking**: Use CI/CD pipeline artifacts
+- **Comparison**: Use pytest's built-in comparison and diff tools
+
+If you need to access old results:
+```python
+from evals.storage import EvalStorage
+storage = EvalStorage()
+results = storage.get_results(tool_name="commit_changes", limit=10)
+```
+
+## Environment Variables
+
+No changes - the same environment variables work:
+
+- `BETTER_COMMIT_MODEL`: Model to evaluate
+- `ANTHROPIC_API_KEY`: Anthropic API key
+- `OPENAI_API_KEY`: OpenAI API key
+- `JUDGE_MODEL`: Judge model (new, defaults to `gpt-4o`)
+
+## Common Issues
+
+### "No module named 'deepeval'"
+```bash
+cd evals && uv pip install -e .
+```
+
+### "No tests collected"
+Make sure you're in the `evals` directory and test files are named `test_*.py`.
+
+### "API key not found"
+Set required API keys:
+```bash
+export ANTHROPIC_API_KEY=your-key
+export OPENAI_API_KEY=your-key  # Required for judge model
+```
+
+## Need Help?
+
+- DeepEval Documentation: https://docs.confident-ai.com/
+- Pytest Documentation: https://docs.pytest.org/
+- Open an issue: https://github.com/rikurb8/best-commits/issues

--- a/evals/MIGRATION.md
+++ b/evals/MIGRATION.md
@@ -12,19 +12,21 @@ This guide explains the migration from the custom evaluation system to DeepEval.
 - Run via: `uv run evals/commit_changes/run_eval.py`
 
 ### After (DeepEval)
-- Pytest-based test suite with `test_*.py` files
+- DeepEval-based test suite with `test_*.py` files
 - DeepEval's GEval metric for standardized evaluation
-- Built-in pytest reporting and storage
+- Built-in reporting with optional cloud dashboards
 - Standard test framework with pass/fail assertions
-- Run via: `pytest commit_changes/`
+- Run via: `deepeval test run` (recommended) or `pytest`
 
 ## Key Benefits
 
-1. **Standardization**: Uses industry-standard testing framework (pytest)
-2. **Better Tooling**: Leverage pytest plugins for reporting, coverage, etc.
+1. **Standardization**: Uses industry-standard LLM evaluation framework (DeepEval)
+2. **Better Tooling**: DeepEval CLI with parallel execution and cloud reporting
 3. **Clearer Results**: Pass/fail based on thresholds instead of just scores
 4. **Easier Extension**: Simple to add new metrics and test cases
-5. **CI/CD Integration**: Native pytest support in most CI/CD platforms
+5. **CI/CD Integration**: Native support in most CI/CD platforms
+6. **Parallel Execution**: Run tests faster with `-n` flag
+7. **Cloud Dashboards**: Optional integration with Confident AI platform
 
 ## Migration Steps
 
@@ -41,7 +43,10 @@ This guide explains the migration from the custom evaluation system to DeepEval.
    # Old way
    uv run evals/commit_changes/run_eval.py --case basic_feature
 
-   # New way
+   # New way (recommended)
+   deepeval test run commit_changes/test_commit_eval.py::test_commit_message_generation[basic_feature]
+
+   # Or with pytest (also works)
    pytest commit_changes/test_commit_eval.py::test_commit_message_generation[basic_feature] -v
    ```
 
@@ -50,9 +55,15 @@ This guide explains the migration from the custom evaluation system to DeepEval.
    # Old way
    uv run evals/commit_changes/run_eval.py --summary
 
-   # New way
-   pytest commit_changes/ -v  # Shows pass/fail
-   pytest --html=report.html --self-contained-html  # Generate HTML report
+   # New way (recommended)
+   deepeval test run  # Shows pass/fail with DeepEval reporting
+
+   # Optional: cloud dashboard
+   deepeval login  # One-time setup
+   deepeval test run  # Automatically syncs to cloud
+
+   # Or with pytest
+   pytest commit_changes/ -v
    ```
 
 ### For Developers
@@ -69,10 +80,10 @@ This guide explains the migration from the custom evaluation system to DeepEval.
    # Add files...
    uv run evals/commit_changes/run_eval.py --case new_case
 
-   # New way: Create files, pytest auto-discovers
+   # New way: Create files, DeepEval auto-discovers
    mkdir evals/commit_changes/new_case
    # Add files...
-   pytest commit_changes/ -v  # Automatically finds and runs new case
+   deepeval test run commit_changes/test_commit_eval.py  # Automatically finds and runs new case
    ```
 
 3. **Customizing evaluation**:
@@ -97,15 +108,16 @@ If you need the old behavior:
 uv run evals/commit_changes/run_eval.py  # Still works
 ```
 
-However, we recommend migrating to the new pytest-based system.
+However, we recommend migrating to the new DeepEval-based system.
 
 ## Database Storage
 
-The old SQLite storage system (`evals/storage/`) is deprecated. DeepEval and pytest provide their own result storage and reporting mechanisms:
+The old SQLite storage system (`evals/storage/`) is deprecated. DeepEval provides better result storage and reporting:
 
-- **Test results**: Use `pytest --json-report` or `pytest --html`
-- **Historical tracking**: Use CI/CD pipeline artifacts
-- **Comparison**: Use pytest's built-in comparison and diff tools
+- **Test results**: `deepeval test run` automatically tracks results
+- **Cloud dashboards**: `deepeval login` + `deepeval test run` syncs to Confident AI
+- **Historical tracking**: Use CI/CD pipeline artifacts or Confident AI platform
+- **Comparison**: Built-in comparison in cloud dashboards
 
 If you need to access old results:
 ```python

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,26 +1,33 @@
 # Evals
 
-Automated evaluation system for AI-powered Git tools.
+Automated evaluation system for AI-powered Git tools using [DeepEval](https://docs.confident-ai.com/).
 
 ## Quick Start
 
 ```bash
-# Evaluate commit message generation
-uv run evals/commit_changes/run_eval.py
+# Install dependencies
+cd evals && uv pip install -e .
 
-# Evaluate code review generation
-uv run evals/review_changes/run_eval.py
+# Run all evaluations
+pytest
 
-# View results summary
-uv run evals/commit_changes/run_eval.py --summary
-uv run evals/review_changes/run_eval.py --summary
+# Run commit message evaluations only
+pytest commit_changes/test_commit_eval.py -v
+
+# Run code review evaluations only
+pytest review_changes/test_review_eval.py -v
+
+# Run a specific test case
+pytest commit_changes/test_commit_eval.py::test_commit_message_generation[basic_feature] -v
 ```
 
 ## Structure
 
 ```
 evals/
-├── storage/              # SQLite-based results storage
+├── pyproject.toml        # Package config with deepeval dependency
+├── conftest.py           # Pytest/deepeval configuration
+├── storage/              # Legacy SQLite storage (deprecated)
 │   ├── database.py       # Storage API
 │   ├── schema.sql        # Database schema
 │   └── README.md         # API documentation
@@ -28,66 +35,148 @@ evals/
 │   ├── basic_feature/    # Test: feature addition
 │   ├── bugfix/           # Test: bug fix
 │   ├── refactor/         # Test: refactoring
-│   └── run_eval.py       # Eval runner
+│   ├── test_commit_eval.py  # Deepeval test suite
+│   └── run_eval.py       # Legacy eval runner (deprecated)
 └── review_changes/       # Code review evals
     ├── security_issue/   # Test: security vulnerability
     ├── code_quality/     # Test: quality improvements
     ├── breaking_change/  # Test: API breaking changes
-    └── run_eval.py       # Eval runner
+    ├── test_review_eval.py  # Deepeval test suite
+    └── run_eval.py       # Legacy eval runner (deprecated)
 ```
+
+## Migration to DeepEval
+
+This evaluation suite has been migrated from a custom evaluation system to DeepEval, providing:
+
+- **Standard Testing Framework**: Uses pytest for test discovery and execution
+- **Built-in Metrics**: Leverages DeepEval's GEval metric for LLM-based evaluation
+- **Better Reporting**: Integrated test results and detailed failure analysis
+- **Easier Extension**: Simple to add new test cases and metrics
+
+### Legacy Scripts
+
+The old `run_eval.py` scripts and SQLite storage are deprecated but kept for backwards compatibility. Use the new pytest-based tests instead.
 
 ## Usage Examples
 
-### Run All Test Cases
+### Run All Tests
 ```bash
-uv run evals/commit_changes/run_eval.py
-uv run evals/review_changes/run_eval.py
+cd evals
+pytest -v
+```
+
+### Run Specific Tool Tests
+```bash
+# Commit message tests
+pytest commit_changes/ -v
+
+# Code review tests
+pytest review_changes/ -v
 ```
 
 ### Run Specific Test Case
 ```bash
-uv run evals/commit_changes/run_eval.py --case basic_feature
-uv run evals/review_changes/run_eval.py --case security_issue
+pytest commit_changes/test_commit_eval.py::test_commit_message_generation[basic_feature] -v
+pytest review_changes/test_review_eval.py::test_code_review_generation[security_issue] -v
 ```
 
 ### Test Different Models
 ```bash
-uv run evals/commit_changes/run_eval.py --model gpt-4o
-uv run evals/commit_changes/run_eval.py --model claude-sonnet-4-5-20250514
+# Set model via environment variable
+BETTER_COMMIT_MODEL=gpt-4o pytest commit_changes/ -v
+BETTER_COMMIT_MODEL=claude-sonnet-4-20250514 pytest commit_changes/ -v
 ```
 
-### View Results Summary
+### Generate Test Report
 ```bash
-uv run evals/commit_changes/run_eval.py --summary
-uv run evals/review_changes/run_eval.py --summary
+# Generate HTML report
+pytest --html=report.html --self-contained-html
+
+# Generate JSON report for CI/CD
+pytest --json-report --json-report-file=report.json
 ```
 
 ## How It Works
 
 1. **Test Cases**: Each case contains a sample git diff and expected elements
 2. **Tool Execution**: The actual tool (`commit_changes` or `review_changes`) runs on the diff
-3. **Judge Evaluation**: Claude Sonnet 4.5 scores the output 1-100 based on criteria
-4. **Storage**: Results saved to SQLite database for historical tracking
-5. **Comparison**: New results compared against previous runs
+3. **DeepEval Metrics**: GEval metric uses an LLM judge (GPT-4) to score outputs based on criteria
+4. **Assertions**: Tests pass/fail based on configurable thresholds (default: 70%)
+5. **Reporting**: Standard pytest output with detailed failure analysis
 
 ## Evaluation Criteria
 
-### Commit Messages (1-100 points)
-- **Conventional format** (20 pts): Correct prefix, ≤50 char summary
-- **Clarity** (30 pts): Clear, understandable message
-- **Conciseness** (20 pts): No redundant information
-- **Informativeness** (30 pts): Captures what and why
+### Commit Messages
+DeepEval's GEval metric evaluates commit messages based on:
 
-### Code Reviews (1-100 points)
-- **Score accuracy** (25 pts): Gerrit score matches severity
-- **Completeness** (25 pts): Covers all aspects
-- **Actionability** (25 pts): Clear, specific feedback
-- **Tone** (25 pts): Professional, constructive
+- **Conventional format** (20%): Correct prefix (feat:/fix:/refactor:), summary ≤50 chars
+- **Clarity** (30%): Clear, understandable message
+- **Conciseness** (20%): No redundant information
+- **Informativeness** (30%): Captures what and why
+
+Threshold: 70% (0.7) - Tests pass if the score is above this threshold.
+
+### Code Reviews
+DeepEval's GEval metric evaluates code reviews based on:
+
+- **Score accuracy** (25%): Gerrit score (-2 to +2) matches severity of issues
+- **Completeness** (25%): Covers correctness, quality, tests, documentation
+- **Actionability** (25%): Clear, specific, actionable feedback
+- **Tone** (25%): Professional, constructive, balanced
+
+Threshold: 70% (0.7) - Tests pass if the score is above this threshold.
 
 ## Adding New Test Cases
 
 1. Create directory: `evals/{tool_name}/{case_name}/`
-2. Add `README.md` (description, expected elements)
-3. Add `diff.txt` (sample git diff)
+2. Add `README.md` (description of the test case)
+3. Add `diff.txt` (sample git diff to test)
 4. Add `expected_elements.json` (evaluation checklist)
-5. Run eval: `uv run evals/{tool_name}/run_eval.py --case {case_name}`
+5. The test will be automatically discovered and run with: `pytest {tool_name}/ -v`
+
+Example:
+```bash
+mkdir -p evals/commit_changes/new_case
+echo "feat: add new feature" > evals/commit_changes/new_case/diff.txt
+echo '{"elements": ["mentions feature", "uses feat: prefix"]}' > evals/commit_changes/new_case/expected_elements.json
+pytest commit_changes/ -v
+```
+
+## Configuration
+
+### Environment Variables
+
+- `BETTER_COMMIT_MODEL`: Model to evaluate (default: `claude-haiku-4-5-20251001`)
+- `JUDGE_MODEL`: Judge model for evaluation (default: `gpt-4o`)
+- `ANTHROPIC_API_KEY`: Anthropic API key
+- `OPENAI_API_KEY`: OpenAI API key (required for default judge model)
+
+### Customizing Metrics
+
+You can customize the evaluation criteria by modifying the GEval metric in the test files:
+
+```python
+commit_message_metric = GEval(
+    name="commit_message_quality",
+    criteria="Your custom criteria here...",
+    threshold=0.7,  # Adjust threshold as needed
+    model="gpt-4o",  # Change judge model if desired
+)
+```
+
+## Integration with CI/CD
+
+The evaluation suite can be integrated into CI/CD pipelines:
+
+```yaml
+# Example GitHub Actions workflow
+- name: Run evaluations
+  run: |
+    cd evals
+    uv pip install -e .
+    pytest --json-report --json-report-file=results.json
+  env:
+    ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+    OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+```

--- a/evals/__init__.py
+++ b/evals/__init__.py
@@ -1,0 +1,3 @@
+"""Evaluation suite for best-commits AI tools using DeepEval."""
+
+__version__ = "0.1.0"

--- a/evals/commit_changes/__init__.py
+++ b/evals/commit_changes/__init__.py
@@ -1,0 +1,1 @@
+"""Commit message generation evaluation tests."""

--- a/evals/commit_changes/test_commit_eval.py
+++ b/evals/commit_changes/test_commit_eval.py
@@ -1,0 +1,123 @@
+"""Deepeval-based evaluation tests for commit_changes tool."""
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Dict, Any
+
+import pytest
+from deepeval import assert_test
+from deepeval.metrics import GEval
+from deepeval.test_case import LLMTestCase, LLMTestCaseParams
+
+# Add project root to path
+project_root = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(project_root))
+
+
+def load_test_case(case_name: str) -> Dict[str, Any]:
+    """Load test case data from directory."""
+    case_path = Path(__file__).parent / case_name
+    diff_path = case_path / "diff.txt"
+    expected_path = case_path / "expected_elements.json"
+
+    if not diff_path.exists() or not expected_path.exists():
+        raise FileNotFoundError(f"Missing required files in {case_path}")
+
+    return {
+        "diff": diff_path.read_text(),
+        "expected": json.loads(expected_path.read_text()),
+    }
+
+
+def generate_commit_message(diff: str, model: str) -> str:
+    """Generate commit message using the tool's logic."""
+    from tools.commit_changes.commit_changes.main import generate_commit_message as tool_generate
+
+    # Set the model via environment variable
+    original_model = os.getenv("BETTER_COMMIT_MODEL")
+    os.environ["BETTER_COMMIT_MODEL"] = model
+
+    try:
+        # Simulate the tool's input format
+        changes = {
+            "status": "M  file1.py\nM  file2.py",
+            "diff": diff,
+            "staged_diff": diff,
+        }
+
+        return tool_generate(changes)
+    finally:
+        # Restore original model
+        if original_model:
+            os.environ["BETTER_COMMIT_MODEL"] = original_model
+        else:
+            os.environ.pop("BETTER_COMMIT_MODEL", None)
+
+
+# Discover all test cases
+def get_test_cases():
+    """Discover all test case directories."""
+    cases_dir = Path(__file__).parent
+    return [
+        d.name
+        for d in cases_dir.iterdir()
+        if d.is_dir() and (d / "diff.txt").exists()
+    ]
+
+
+def get_commit_message_metric():
+    """Create the evaluation metric (lazy initialization to avoid API key issues at import time)."""
+    judge_model = os.getenv("JUDGE_MODEL", "gpt-4o")
+
+    return GEval(
+        name="commit_message_quality",
+        criteria=(
+            "Evaluate the quality of an AI-generated commit message based on: "
+            "1. Conventional format (20%): Correct prefix (feat:/fix:/refactor:), summary ≤50 chars. "
+            "2. Clarity (30%): Clear, understandable, mentions key changes. "
+            "3. Conciseness (20%): No redundant information, focused. "
+            "4. Informativeness (30%): Captures what and why, matches diff content."
+        ),
+        evaluation_params=[
+            LLMTestCaseParams.INPUT,
+            LLMTestCaseParams.ACTUAL_OUTPUT,
+            LLMTestCaseParams.EXPECTED_OUTPUT,
+        ],
+        threshold=0.7,  # 70% threshold for passing
+        model=judge_model,  # Judge model
+    )
+
+
+# Parametrize tests for all cases
+@pytest.mark.commit
+@pytest.mark.parametrize("case_name", get_test_cases())
+def test_commit_message_generation(case_name: str):
+    """Test commit message generation with deepeval."""
+    # Get model from environment or use default
+    model = os.getenv("BETTER_COMMIT_MODEL", "claude-haiku-4-5-20251001")
+
+    # Load test case
+    test_data = load_test_case(case_name)
+
+    # Generate commit message
+    actual_output = generate_commit_message(test_data["diff"], model)
+
+    # Create deepeval test case
+    test_case = LLMTestCase(
+        input=test_data["diff"],
+        actual_output=actual_output,
+        expected_output=json.dumps(test_data["expected"], indent=2),
+    )
+
+    # Get metric (lazy initialization)
+    commit_message_metric = get_commit_message_metric()
+
+    # Assert using deepeval
+    assert_test(test_case, [commit_message_metric])
+
+
+if __name__ == "__main__":
+    # Allow running as standalone script
+    pytest.main([__file__, "-v", "--tb=short"])

--- a/evals/conftest.py
+++ b/evals/conftest.py
@@ -1,4 +1,4 @@
-"""Pytest configuration for deepeval tests."""
+"""Pytest configuration for DeepEval tests."""
 
 import os
 import sys
@@ -12,7 +12,7 @@ sys.path.insert(0, str(project_root))
 
 
 def pytest_configure(config):
-    """Configure pytest for deepeval."""
+    """Configure pytest for DeepEval."""
     # Register custom markers
     config.addinivalue_line("markers", "commit: tests for commit message generation")
     config.addinivalue_line("markers", "review: tests for code review generation")
@@ -21,7 +21,7 @@ def pytest_configure(config):
 @pytest.fixture(autouse=True)
 def setup_environment():
     """Ensure required environment variables are set."""
-    # Check for API keys
+    # Check for API keys (either for model under test or judge model)
     api_keys = [
         "ANTHROPIC_API_KEY",
         "OPENAI_API_KEY",
@@ -32,15 +32,3 @@ def setup_environment():
 
     if not has_key:
         pytest.skip("No API key found. Set ANTHROPIC_API_KEY or OPENAI_API_KEY")
-
-
-@pytest.fixture
-def eval_model():
-    """Get the model to use for evaluation."""
-    return os.getenv("BETTER_COMMIT_MODEL", "claude-haiku-4-5-20251001")
-
-
-@pytest.fixture
-def judge_model():
-    """Get the judge model for evaluation."""
-    return os.getenv("JUDGE_MODEL", "gpt-4o")

--- a/evals/conftest.py
+++ b/evals/conftest.py
@@ -1,0 +1,46 @@
+"""Pytest configuration for deepeval tests."""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add project root to Python path
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+
+def pytest_configure(config):
+    """Configure pytest for deepeval."""
+    # Register custom markers
+    config.addinivalue_line("markers", "commit: tests for commit message generation")
+    config.addinivalue_line("markers", "review: tests for code review generation")
+
+
+@pytest.fixture(autouse=True)
+def setup_environment():
+    """Ensure required environment variables are set."""
+    # Check for API keys
+    api_keys = [
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "GIT_API_KEY",  # Legacy support
+    ]
+
+    has_key = any(os.getenv(key) for key in api_keys)
+
+    if not has_key:
+        pytest.skip("No API key found. Set ANTHROPIC_API_KEY or OPENAI_API_KEY")
+
+
+@pytest.fixture
+def eval_model():
+    """Get the model to use for evaluation."""
+    return os.getenv("BETTER_COMMIT_MODEL", "claude-haiku-4-5-20251001")
+
+
+@pytest.fixture
+def judge_model():
+    """Get the judge model for evaluation."""
+    return os.getenv("JUDGE_MODEL", "gpt-4o")

--- a/evals/pyproject.toml
+++ b/evals/pyproject.toml
@@ -1,0 +1,39 @@
+[project]
+name = "best-commits-evals"
+version = "0.1.0"
+description = "Evaluation suite for best-commits AI tools using deepeval"
+readme = "README.md"
+requires-python = ">=3.10"
+license = "MIT"
+authors = [
+    { name = "best-commits contributors" }
+]
+
+dependencies = [
+    "deepeval>=1.0.0",
+    "litellm>=1.0.0",
+    "rich>=13.0.0",
+    "pytest>=7.0.0",
+    "pytest-html>=3.0.0",
+    "pytest-json-report>=1.5.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/rikurb8/best-commits"
+Repository = "https://github.com/rikurb8/best-commits"
+Issues = "https://github.com/rikurb8/best-commits/issues"
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+packages = ["storage"]
+
+[tool.pytest.ini_options]
+testpaths = ["commit_changes", "review_changes"]
+python_files = ["test_*.py"]
+markers = [
+    "commit: tests for commit message generation",
+    "review: tests for code review generation",
+]

--- a/evals/review_changes/__init__.py
+++ b/evals/review_changes/__init__.py
@@ -1,0 +1,1 @@
+"""Code review generation evaluation tests."""

--- a/evals/review_changes/test_review_eval.py
+++ b/evals/review_changes/test_review_eval.py
@@ -1,0 +1,159 @@
+"""Deepeval-based evaluation tests for review_changes tool."""
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Dict, Any
+
+import pytest
+from deepeval import assert_test
+from deepeval.metrics import GEval
+from deepeval.test_case import LLMTestCase, LLMTestCaseParams
+
+# Add project root to path
+project_root = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(project_root))
+
+
+def load_test_case(case_name: str) -> Dict[str, Any]:
+    """Load test case data from directory."""
+    case_path = Path(__file__).parent / case_name
+    diff_path = case_path / "diff.txt"
+    expected_path = case_path / "expected_elements.json"
+
+    if not diff_path.exists() or not expected_path.exists():
+        raise FileNotFoundError(f"Missing required files in {case_path}")
+
+    return {
+        "diff": diff_path.read_text(),
+        "expected": json.loads(expected_path.read_text()),
+    }
+
+
+def generate_review(diff: str, model: str) -> str:
+    """Generate code review using the tool's logic."""
+    from tools.review_changes.review_changes.main import review_changes as tool_review
+
+    # Set the model via environment variable
+    original_model = os.getenv("BETTER_COMMIT_MODEL")
+    os.environ["BETTER_COMMIT_MODEL"] = model
+
+    try:
+        # Simulate the tool's input format
+        changes = {
+            "status": "A  file.py",
+            "diff": diff,
+            "staged_diff": diff,
+        }
+
+        return tool_review(changes)
+    finally:
+        # Restore original model
+        if original_model:
+            os.environ["BETTER_COMMIT_MODEL"] = original_model
+        else:
+            os.environ.pop("BETTER_COMMIT_MODEL", None)
+
+
+def extract_gerrit_score(review: str) -> int:
+    """Extract Gerrit score from review text."""
+    # Look for patterns like "Score: +1" or "**Score:** -2"
+    patterns = [
+        r"Score:\s*([+-]?\d+)",
+        r"\*\*Score:\*\*\s*([+-]?\d+)",
+        r"Gerrit Score:\s*([+-]?\d+)",
+    ]
+
+    for pattern in patterns:
+        match = re.search(pattern, review, re.IGNORECASE)
+        if match:
+            return int(match.group(1))
+
+    # Fallback: look for standalone +2, +1, 0, -1, -2 near beginning
+    lines = review.split("\n")[:10]
+    for line in lines:
+        if re.match(r"^[+-]?[012]$", line.strip()):
+            return int(line.strip())
+
+    return 0  # Default if not found
+
+
+# Discover all test cases
+def get_test_cases():
+    """Discover all test case directories."""
+    cases_dir = Path(__file__).parent
+    return [
+        d.name
+        for d in cases_dir.iterdir()
+        if d.is_dir() and (d / "diff.txt").exists()
+    ]
+
+
+def get_code_review_metric():
+    """Create the evaluation metric (lazy initialization to avoid API key issues at import time)."""
+    judge_model = os.getenv("JUDGE_MODEL", "gpt-4o")
+
+    return GEval(
+        name="code_review_quality",
+        criteria=(
+            "Evaluate the quality of an AI-generated code review based on: "
+            "1. Score accuracy (25%): Gerrit score (-2 to +2) matches severity of issues. "
+            "2. Completeness (25%): Covers correctness, quality, tests, documentation. "
+            "3. Actionability (25%): Clear, specific, actionable feedback. "
+            "4. Tone (25%): Professional, constructive, balanced."
+        ),
+        evaluation_params=[
+            LLMTestCaseParams.INPUT,
+            LLMTestCaseParams.ACTUAL_OUTPUT,
+            LLMTestCaseParams.EXPECTED_OUTPUT,
+        ],
+        threshold=0.7,  # 70% threshold for passing
+        model=judge_model,  # Judge model
+    )
+
+
+# Parametrize tests for all cases
+@pytest.mark.review
+@pytest.mark.parametrize("case_name", get_test_cases())
+def test_code_review_generation(case_name: str):
+    """Test code review generation with deepeval."""
+    # Get model from environment or use default
+    model = os.getenv("BETTER_COMMIT_MODEL", "claude-haiku-4-5-20251001")
+
+    # Load test case
+    test_data = load_test_case(case_name)
+
+    # Generate review
+    actual_output = generate_review(test_data["diff"], model)
+
+    # Extract Gerrit score for additional validation
+    gerrit_score = extract_gerrit_score(actual_output)
+
+    # Add Gerrit score info to expected output for evaluation
+    expected_with_gerrit = test_data["expected"].copy()
+    expected_with_gerrit["note"] = f"Review should provide a Gerrit score (-2 to +2)"
+
+    # Create deepeval test case
+    test_case = LLMTestCase(
+        input=test_data["diff"],
+        actual_output=actual_output,
+        expected_output=json.dumps(expected_with_gerrit, indent=2),
+    )
+
+    # Get metric (lazy initialization)
+    code_review_metric = get_code_review_metric()
+
+    # Assert using deepeval
+    assert_test(test_case, [code_review_metric])
+
+    # Additional assertion for Gerrit score validity
+    assert -2 <= gerrit_score <= 2, (
+        f"Gerrit score {gerrit_score} out of valid range (-2 to +2)"
+    )
+
+
+if __name__ == "__main__":
+    # Allow running as standalone script
+    pytest.main([__file__, "-v", "--tb=short"])


### PR DESCRIPTION
Migrates the evaluation system from custom LLM-based scoring to DeepEval,
providing a standardized testing framework with better tooling and integration.

Changes:
- Add evals/pyproject.toml with DeepEval and pytest dependencies
- Create pytest-based test suites for commit_changes and review_changes
- Replace custom judge prompts with DeepEval's GEval metric
- Add conftest.py with shared pytest configuration and fixtures
- Update README.md with DeepEval usage instructions and migration guide
- Add MIGRATION.md to document transition from old system
- Lazy-initialize metrics to avoid API key issues at import time

Key improvements:
- Standard pytest framework for test discovery and execution
- Built-in metrics with GEval for custom evaluation criteria
- Better CI/CD integration with native pytest support
- Clearer pass/fail results based on configurable thresholds (70%)
- Easier extension with simple test case discovery

Legacy run_eval.py scripts remain for backwards compatibility but are deprecated.
Test cases (diff.txt and expected_elements.json) remain unchanged and
are automatically discovered by pytest.